### PR TITLE
OptionalEntity#flatMap()がnullを返す

### DIFF
--- a/dbflute-runtime/src/main/java/org/dbflute/optional/BaseOptional.java
+++ b/dbflute-runtime/src/main/java/org/dbflute/optional/BaseOptional.java
@@ -218,8 +218,15 @@ public abstract class BaseOptional<OBJ> implements OptionalThing<OBJ> {
             String msg = "The argument 'mapper' should not be null.";
             throw new IllegalArgumentException(msg);
         }
-        return exists() ? mapper.apply(_obj) : null;
+        return exists() ? mapper.apply(_obj) : createOptionalFlatMappedObject(null);
     }
+
+    /**
+     * @param <ARG> The type of value for optional thing.
+     * @param obj The plain object for the optional thing. (NullAllowed: if null, return s empty optional)
+     * @return The new-created instance of optional thing. (NotNull)
+     */
+    protected abstract <ARG> OptionalThing<ARG> createOptionalFlatMappedObject(ARG obj);
 
     // ===================================================================================
     //                                                                   Standard Optional

--- a/dbflute-runtime/src/main/java/org/dbflute/optional/OptionalEntity.java
+++ b/dbflute-runtime/src/main/java/org/dbflute/optional/OptionalEntity.java
@@ -31,7 +31,7 @@ import org.dbflute.helper.message.ExceptionMessageBuilder;
  *     <span style="color: #3F7E5E">// called if present, or exception</span>
  *     ... = <span style="color: #553000">member</span>.getMemberName();
  * });
- * 
+ *
  * <span style="color: #3F7E5E">// if it might be no data, ...</span>
  * <span style="color: #0000C0">memberBhv</span>.<span style="color: #994747">selectEntity</span>(<span style="color: #553000">cb</span> <span style="color: #90226C; font-weight: bold"><span style="font-size: 120%">-</span>&gt;</span> <span style="color: #553000">cb</span>.acceptPK(<span style="color: #2A00FF">1</span>)).<span style="color: #CC4747">ifPresent</span>(<span style="color: #553000">member</span> <span style="color: #90226C; font-weight: bold"><span style="font-size: 120%">-</span>&gt;</span> {
  *     <span style="color: #3F7E5E">// called if present</span>
@@ -302,6 +302,12 @@ public class OptionalEntity<ENTITY> extends BaseOptional<ENTITY> {
     public <RESULT> OptionalThing<RESULT> flatMap(OptionalThingFunction<? super ENTITY, OptionalThing<RESULT>> entityLambda) {
         assertEntityLambdaNotNull(entityLambda);
         return callbackFlatMapping(entityLambda);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    protected <ARG> OptionalEntity<ARG> createOptionalFlatMappedObject(ARG obj) {
+        return new OptionalEntity<ARG>(obj, _thrower);
     }
 
     // _/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/

--- a/dbflute-runtime/src/main/java/org/dbflute/optional/OptionalObject.java
+++ b/dbflute-runtime/src/main/java/org/dbflute/optional/OptionalObject.java
@@ -138,6 +138,12 @@ public class OptionalObject<OBJ> extends BaseOptional<OBJ> {
     }
 
     /** {@inheritDoc} */
+    @Override
+    protected <ARG> OptionalObject<ARG> createOptionalFlatMappedObject(ARG obj) {
+        return new OptionalObject<ARG>(obj, _thrower);
+    }
+
+    /** {@inheritDoc} */
     public OBJ orElse(OBJ other) {
         return directlyGetOrElse(other);
     }

--- a/dbflute-runtime/src/main/java/org/dbflute/optional/OptionalScalar.java
+++ b/dbflute-runtime/src/main/java/org/dbflute/optional/OptionalScalar.java
@@ -138,6 +138,12 @@ public class OptionalScalar<SCALAR> extends BaseOptional<SCALAR> {
     }
 
     /** {@inheritDoc} */
+    @Override
+    protected <ARG> OptionalScalar<ARG> createOptionalFlatMappedObject(ARG obj) {
+        return new OptionalScalar<ARG>(obj, _thrower);
+    }
+
+    /** {@inheritDoc} */
     public SCALAR orElse(SCALAR other) {
         return directlyGetOrElse(other);
     }

--- a/dbflute-runtime/src/test/java/org/dbflute/optional/OptionalEntityTest.java
+++ b/dbflute-runtime/src/test/java/org/dbflute/optional/OptionalEntityTest.java
@@ -113,6 +113,15 @@ public class OptionalEntityTest extends RuntimeTestCase {
         assertTrue(firstOpt.equals(secondOpt));
     }
 
+    public void test_empty_flatmap() throws Exception {
+        // ## Arrange ##
+        OptionalEntity<MockEntity> opt = prepareOpt(null);
+        // ## Act ##
+        MockEntity mock = opt.flatMap(OptionalEntity::of).orElseNull();
+        // ## Assert ##
+        assertNull(mock);
+    }
+
     // ===================================================================================
     //                                                                         Test Helper
     //                                                                         ===========


### PR DESCRIPTION
OptionalEntityが空の場合、OptionalEntity#flatMap()がnullを返すため、NullPointerExceptionが発生します。
```java
OptionalEntity<Member> member = memberBhv.selectEntity(cb -> {
	cb.setupSelect_MemberWithdrawalAsOne();
	cb.query().setMemberId_Equal(Integer.MAX_VALUE);
});
member.flatMap(m -> m.getMemberWithdrawalAsOne())
	.map(w -> w.getWithdrawalDatetime()) // memberが存在しない場合、ここでNullPointerException
	.orElseNull();
```