### PR TITLE
modify datamodel.vm to remove unnecessary space from innerText

### DIFF
--- a/dbflute-engine/embedded/templates/doc/html/datamodel.vm
+++ b/dbflute-engine/embedded/templates/doc/html/datamodel.vm
@@ -1914,7 +1914,7 @@ Decomment.prototype = {
 
 				var commentElement = column.querySelector('.commentcell');
 				var tableName = that.getTableNameFromElement(table);
-				var columnName = column.querySelector('.columnnamecell').innerText;
+				var columnName = column.querySelector('.columnnamecell').innerText.trim();
 				var columnProperty = that.storeClient.getColumnPickup(tableName, columnName) || new PickupTableProperty(tableName, columnName)
 				commentElement.onclick = that.createSaveDecommentFunction(columnProperty);
 			});


### PR DESCRIPTION
## Implementation
- [x] remove space from innerText
  Usually, innerText field of element object does not contain any space but just literals in element.
  But it contains some space actually on the condition of using google chrome browser (I'm not sure about the reason...).
  This caused situations that users cannot save any decomment of table calumn.
  My modification is for removing the space forcibly.
