### PR TITLE
dbflute-coreのGithub ActionでMySQL 5.7がpullできるよう修正

### DIFF
--- a/.github/workflows/test-mysql.yml
+++ b/.github/workflows/test-mysql.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         java: [ '8' ]
-        dbms: [ '5.7.11', '8.0.29' ]
+        dbms: [ '5.7.44', '8.0.29' ]
 
     steps:
     - uses: actions/checkout@v3
@@ -36,7 +36,7 @@ jobs:
         git branch
     - name: Run MySQL
       run: |
-        docker run -p 43306:3306 -e MYSQL_ROOT_PASSWORD=my-secret-pw -e MYSQL_DATABASE=maihamadb -e MYSQL_USER=maihamadb -e MYSQL_PASSWORD=maihamadb -d mysql:${{ matrix.dbms }} --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci --lower-case-table-names=1
+        docker run -p 43306:3306 -e MYSQL_ROOT_PASSWORD=my-secret-pw -e MYSQL_DATABASE=maihamadb -e MYSQL_USER=maihamadb -e MYSQL_PASSWORD=maihamadb -d mysql:${{ matrix.dbms }} --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci --lower-case-table-names=1 --log_bin_trust_function_creators=1
     - name: Build
       run: |
         base_dir=$(pwd)


### PR DESCRIPTION
# 対応したこと
- imageがpullできないので5.7の最新イメージに更新
- プロシージャのReplaceSchemaでエラーになるのでlog_bin_trust_function_creatorsをONにする

まだActionsではエラーになりますが、[dbflute-test-active-dockside](https://github.com/dbflute-test/dbflute-test-active-dockside) がJava17でコンパイルエラーになっているので、このPull Requestとは別にします