### PR TITLE
[Decomment] shaliasでplainなSchemaHTMLのときにdecomment先頭行に空行が入っちゃう

### DIFF
--- a/dbflute-engine/embedded/templates/doc/html/datamodel.vm
+++ b/dbflute-engine/embedded/templates/doc/html/datamodel.vm
@@ -1540,7 +1540,9 @@ var DecommentUtil = new function(){
 		if (!decomment) {
 			return '';
 		}
-		return decomment.replace(/(?:dfalias|shalias):\s*\{[^}]*\}\s*\n?/g, '').trim();
+		var result = decomment.replace(/(?:dfalias|shalias):\s*\{[^}]*\}\s*\n?/g, '');
+		// remove leading <br> to prevent empty line when opening in plain schema html
+		return result.replace(/^<br\s*\/?>/i, '').trim();
 	}
 }
 


### PR DESCRIPTION
## 概要

dbflute/dbflute-intro#550

## 動作確認

**BEFORE**
<img width="960" height="392" alt="Screenshot 2026-02-06 at 22 04 25" src="https://github.com/user-attachments/assets/c8d6f661-f0aa-4068-bec3-f38a548e12d5" />

**AFTER**
<img width="978" height="376" alt="Screenshot 2026-02-06 at 22 05 09" src="https://github.com/user-attachments/assets/3c1ef375-22bd-4fdc-bc0a-31cd352c4733" />
